### PR TITLE
Bug/4 clubs shouldnt be able to book more than 12 places per competition

### DIFF
--- a/server.py
+++ b/server.py
@@ -53,12 +53,24 @@ def book(competition,club):
 def purchasePlaces():
     competition = [c for c in competitions if c['name'] == request.form['competition']][0]
     club = [c for c in clubs if c['name'] == request.form['club']][0]
+    try:
+        club[f"{competition['name']}_{competition['date']}_purchase_history"]
+    except KeyError:
+        club[f"{competition['name']}_{competition['date']}_purchase_history"] = 0
+    print(club)
+    print(club[f"{competition['name']}_{competition['date']}_purchase_history"])
+
     placesRequired = int(request.form['places'])
     available_club_points = int(club['points'])
     if placesRequired > available_club_points:
         flash("Club doesn't have enough points to book this amount of places.")
+    elif placesRequired + club[f"{competition['name']}_{competition['date']}_purchase_history"] > 12:
+        flash("You can't book more than 12 places in a single competition.")
     else:
         competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
+        print(club[f"{competition['name']}_{competition['date']}_purchase_history"])
+        club[f"{competition['name']}_{competition['date']}_purchase_history"] += placesRequired
+        print(club[f"{competition['name']}_{competition['date']}_purchase_history"])
         flash('Great-booking complete!')
     return render_template('welcome.html', club=club, competitions=competitions)
 

--- a/server.py
+++ b/server.py
@@ -55,11 +55,11 @@ def purchasePlaces():
     club = [c for c in clubs if c['name'] == request.form['club']][0]
     placesRequired = int(request.form['places'])
     available_club_places = int(club['points'])
-    if placesRequired <= available_club_places:
+    if placesRequired > available_club_places:
+        flash("Club doesn't have enough points to book this amount of places.")
+    else:
         competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
         flash('Great-booking complete!')
-    else:
-        flash("Club doesn't have enough points to book this amount of places.")
     return render_template('welcome.html', club=club, competitions=competitions)
 
 

--- a/server.py
+++ b/server.py
@@ -57,8 +57,6 @@ def purchasePlaces():
         club[f"{competition['name']}_{competition['date']}_purchase_history"]
     except KeyError:
         club[f"{competition['name']}_{competition['date']}_purchase_history"] = 0
-    print(club)
-    print(club[f"{competition['name']}_{competition['date']}_purchase_history"])
 
     placesRequired = int(request.form['places'])
     available_club_points = int(club['points'])
@@ -68,9 +66,7 @@ def purchasePlaces():
         flash("You can't book more than 12 places in a single competition.")
     else:
         competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
-        print(club[f"{competition['name']}_{competition['date']}_purchase_history"])
         club[f"{competition['name']}_{competition['date']}_purchase_history"] += placesRequired
-        print(club[f"{competition['name']}_{competition['date']}_purchase_history"])
         flash('Great-booking complete!')
     return render_template('welcome.html', club=club, competitions=competitions)
 

--- a/tests/unit_tests/test_routes.py
+++ b/tests/unit_tests/test_routes.py
@@ -126,13 +126,20 @@ class TestPurchasePlaces:
     #     data = response.data.decode()
     #     assert "You can't book a negative number of places" in data
     #     assert "Great-booking complete!" not in data
-    #
-    # def test_purchasePlaces_should_not_allow_more_than_12_places_booking(self, client, mock_normal_data_from_json):
-    #     response = client.post('/purchasePlaces', data={'places': '13', 'club': 'Simply Lift', 'competition': 'Spring Festival'})
-    #     data = response.data.decode()
-    #     assert "You can't book more than 12 places for one competition"
-    #     assert "Great-booking complete!" not in data
-    #
+
+    def test_purchasePlaces_should_not_allow_booking_more_than_12_places_in_one_purchase(self, client, mock_normal_data_from_json):
+        response = client.post('/purchasePlaces', data={'places': '13', 'club': 'Simply Lift', 'competition': 'Spring Festival'})
+        data = response.data.decode()
+        assert "You can't book more than 12 places in a single competition."
+        assert "Great-booking complete!" not in data
+
+    def test_purchasePlaces_should_not_allow_booking_more_than_12_places_in_two_purchase(self, client, mock_normal_data_from_json):
+        response = client.post('/purchasePlaces', data={'places': '7', 'club': 'Simply Lift', 'competition': 'Spring Festival'})
+        response = client.post('/purchasePlaces', data={'places': '6', 'club': 'Simply Lift', 'competition': 'Spring Festival'})
+        data = response.data.decode()
+        assert "You can't book more than 12 places in a single competition."
+        assert "Great-booking complete!" not in data
+
     # def test_purchasePlaces_should_not_allow_booking_for_pasts_competitions(self, client, mock_normal_data_from_json):
     #     response = client.post('/purchasePlaces', data={'places': '2', 'club': 'Iron Temple', 'competition': 'Fall Classic'})
     #     data = response.data.decode()


### PR DESCRIPTION
See issue #6 

When:

A secretary tries to book more than 12 places in one competition

Then:

Those places are confirmed

Expected:

They should be able to book no more than 12 places.
The UI should prevent them from booking more than 12 places.
The places are correctly deducted from the competition.